### PR TITLE
Fix: Infinite Loop on Non-Integer Input

### DIFF
--- a/tictactoe.c
+++ b/tictactoe.c
@@ -4,6 +4,13 @@
 
 char board[3][3] = {{'1', '2', '3'}, {'4', '5', '6'}, {'7', '8', '9'}};
 
+// Reads an integer and clears the input buffer to prevent infinite loop on invalid input
+int readInt(int *out) {
+    int result = scanf("%d", out);
+    while (getchar() != '\n');
+    return result;
+}
+
 // Clear the board
 void removeNumber() {
     for (int i = 0; i < 3; i++) {
@@ -93,10 +100,10 @@ int main() {
             printf("Player O, your turn! Enter a number (1-9): ");
         }
         
-        scanf("%d", &input);
+        if (readInt(&input) != 1) input = -1;
         while (!isValidMove(input)) {
             printf("Invalid move! Enter a valid number (1-9): ");
-            scanf("%d", &input);
+            if (readInt(&input) != 1) input = -1;
         }
 
         inputValue(input, player);


### PR DESCRIPTION
I'm working on this under NSoC'26

fixes #12 

**Summary:** Fixes an infinite loop that occurred when a player entered a non-integer value (e.g. `a`, `@`) at the move prompt.

**Problems:**
`scanf("%d", &input)` fails silently on non-integer input:

- Returns `0` (conversion failure)
- Leaves the invalid character in the stdin buffer
- Every subsequent `scanf` call reads the same bad character instantly
- Loop runs forever without waiting for new input
- Requires `Ctrl+C` to exit

**Solution:** Introduced a `readInt()` helper function that:
- Checks the return value of `scanf`
- Flushes the input buffer after every read via `while (getchar() != '\n')`
- Returns whether parsing succeeded

On parse failure, `input` is explicitly set to `-1` so `isValidMove()` rejects it cleanly and re-prompts the user.

**Changes:**
- **Added** `readInt()` helper function
- **Replaced** bare `scanf` calls in `main()` with `readInt()` + failure check

**Before:**
```
scanf("%d", &input);
while (!isValidMove(input)) {
    printf("Invalid move! Enter a valid number (1-9): ");
    scanf("%d", &input);
}
```
**After:**
```
if (readInt(&input) != 1) input = -1;
while (!isValidMove(input)) {
    printf("Invalid move! Enter a valid number (1-9): ");
    if (readInt(&input) != 1) input = -1;
}
```

